### PR TITLE
process to add tag without publishing to rc

### DIFF
--- a/.github/workflows/conda-package-build.yml
+++ b/.github/workflows/conda-package-build.yml
@@ -25,3 +25,4 @@ jobs:
     with:
       force-channel-priority: conda-forge, openalea3/label/dev, openalea3
       operating-system: '["ubuntu-latest", "macos-13", "windows-latest"]' # because of plantgl
+      rc-label: "dev"


### PR DESCRIPTION
- purpose having a version with a github tag
- 1st changed rc-label to dev, 2nd push tag 1.4.0 to get 1.4.1 in dev